### PR TITLE
kafka: support async and transactional sending

### DIFF
--- a/plunger-kafka/src/main/java/de/galan/plunger/command/kafka/KafkaCatCommand.java
+++ b/plunger-kafka/src/main/java/de/galan/plunger/command/kafka/KafkaCatCommand.java
@@ -28,14 +28,15 @@ import com.google.common.base.StandardSystemProperty;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+
 import de.galan.commons.time.Durations;
 import de.galan.commons.time.Instants;
 import de.galan.plunger.command.CommandException;
 import de.galan.plunger.command.generic.AbstractCatCommand;
 import de.galan.plunger.domain.Message;
 import de.galan.plunger.domain.PlungerArguments;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 
 
 /**
@@ -43,18 +44,16 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializer;
  */
 public class KafkaCatCommand extends AbstractCatCommand {
 
-	private KafkaConsumer<String, Object> consumer;
-	private Iterator<ConsumerRecord<String, Object>> recordIterator;
-
 	int timeout = 4000;
 	String groupId;
 	String autoOffsetReset;
+	private KafkaConsumer<String, Object> consumer;
+	private Iterator<ConsumerRecord<String, Object>> recordIterator;
 	private String clientId;
 	private boolean commit;
 
 	private Schema schema = null;
 	private EncoderFactory encoderFactory = new EncoderFactory();
-
 
 	@Override
 	protected void initialize(PlungerArguments pa) throws CommandException {
@@ -149,7 +148,7 @@ public class KafkaCatCommand extends AbstractCatCommand {
 					msg.putProperty("kafka.timestamp_type", record.timestampType().toString());
 				}
 
-				for (Header header: record.headers()) {
+				for (Header header : record.headers()) {
 					msg.putProperty(header.key(), new String(header.value(), UTF_8));
 				}
 

--- a/plunger-kafka/src/main/java/de/galan/plunger/command/kafka/KafkaPutCommand.java
+++ b/plunger-kafka/src/main/java/de/galan/plunger/command/kafka/KafkaPutCommand.java
@@ -7,6 +7,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 import java.io.IOException;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.avro.Schema;
@@ -27,12 +28,14 @@ import org.apache.kafka.common.serialization.StringSerializer;
 
 import com.google.common.primitives.Ints;
 
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+
 import de.galan.plunger.command.CommandException;
 import de.galan.plunger.command.generic.AbstractPutCommand;
 import de.galan.plunger.domain.Message;
 import de.galan.plunger.domain.PlungerArguments;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import de.galan.plunger.util.Output;
 
 
 /**
@@ -40,23 +43,41 @@ import io.confluent.kafka.serializers.KafkaAvroSerializer;
  */
 public class KafkaPutCommand extends AbstractPutCommand {
 
+	private final DecoderFactory decoderFactory = new DecoderFactory();
 	private Producer<String, Object> producer;
 	private Schema schema = null;
-	private DecoderFactory decoderFactory = new DecoderFactory();
-
+	private CommandException lastError;
+	private boolean transactional;
+	private boolean sendAsync;
+	private long numAcked = 0;
+	private long numSend = 0;
 
 	@Override
 	protected void initialize(PlungerArguments pa) throws CommandException {
 		super.initialize(pa);
+
+		transactional = determineTransaction(pa);
+		sendAsync = determineAsync(pa);
+
 		Properties props = new Properties();
 		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, KafkaUtils.brokers(pa.getTarget()));
 		props.put(ProducerConfig.ACKS_CONFIG, determineAcksConfig(pa));
-		props.put(ProducerConfig.RETRIES_CONFIG, 0);
-		props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
-		props.put(ProducerConfig.LINGER_MS_CONFIG, 1);
+		props.put(ProducerConfig.BATCH_SIZE_CONFIG, 100_000);
+		props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "lz4");
+		props.put(ProducerConfig.LINGER_MS_CONFIG, 50);
 		props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
 		props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 		props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+		if (determineTransaction(pa)) {
+			transactional = true;
+			props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString());
+			props.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, determineTransactionTimeout(pa));
+			props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+		}
+		else {
+			props.put(ProducerConfig.RETRIES_CONFIG, 0);
+		}
 
 		Integer maxRequestSize = determineMaxRequestSize(pa);
 		if (maxRequestSize != null) {
@@ -69,7 +90,21 @@ public class KafkaPutCommand extends AbstractPutCommand {
 			props.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistry);
 			schema = AvroUtils.getSchema(schemaRegistry, pa.getTarget().getDestination());
 		}
+
 		producer = new KafkaProducer<>(props);
+
+		if (transactional) {
+			producer.initTransactions();
+			producer.beginTransaction();
+		}
+	}
+
+
+	@Override
+	public void onError(CommandException exception) {
+		if (transactional && !closed) {
+			producer.abortTransaction();
+		}
 	}
 
 
@@ -88,42 +123,102 @@ public class KafkaPutCommand extends AbstractPutCommand {
 	}
 
 
+	private boolean determineAsync(PlungerArguments pa) {
+		String param = pa.getTarget().getParameterValue("async");
+		return isNotBlank(param) && Boolean.parseBoolean(param);
+	}
+
+
+	private boolean determineTransaction(PlungerArguments pa) {
+		String param = pa.getTarget().getParameterValue("tx");
+		return isNotBlank(param) && Boolean.parseBoolean(param);
+	}
+
+
+	private int determineTransactionTimeout(PlungerArguments pa) {
+		String param = pa.getTarget().getParameterValue("txTimeout");
+		if (isBlank(param)) {
+			return 300_000;
+		}
+
+		Integer timeout = Ints.tryParse(param);
+		if (timeout == null) {
+			throw new IllegalArgumentException("invalid timeout value");
+		}
+		return timeout;
+	}
+
+
 	@Override
 	protected void sendMessage(PlungerArguments pa, Message message, long count) throws CommandException {
 		Headers headers = mapHeader(message);
 		String topic = pa.getTarget().getDestination();
+
+		numSend++;
 		if (schema == null) {
 			sendMessagePlain(pa, message, headers, topic);
 		}
 		else {
 			sendMessageAvro(pa, message, headers, topic);
 		}
+
+		if (lastError != null) {
+			throw lastError;
+		}
 	}
 
 
 	private void sendMessagePlain(PlungerArguments pa, Message message, Headers headers, String topic) throws CommandException {
-		try {
-			producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), message.getBody(), headers)).get();
+		if (sendAsync) {
+			producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), message.getBody(), headers), (metadata, exception) -> {
+				if (exception != null) {
+					lastError = new CommandException("Failed sending record: " + exception.getMessage(), exception);
+					return;
+				}
+				numAcked++;
+			});
 		}
-		catch (InterruptedException | ExecutionException ex) {
-			throw new CommandException("Failed sending record: " + ex.getMessage(), ex);
+		else {
+			try {
+				producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), message.getBody(), headers)).get();
+				numAcked++;
+			}
+			catch (InterruptedException | ExecutionException ex) {
+				throw new CommandException("Failed sending record: " + ex.getMessage(), ex);
+			}
 		}
 	}
 
 
 	private void sendMessageAvro(PlungerArguments pa, Message message, Headers headers, String topic) throws CommandException {
+		GenericRecord genericRecord;
 		try {
 			String jsonBody = message.getBody();
 			Decoder decoder = decoderFactory.jsonDecoder(schema, jsonBody);
 			DatumReader<GenericData.Record> reader = new GenericDatumReader<>(schema);
-			GenericRecord genericRecord = reader.read(null, decoder);
-			producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), genericRecord, headers)).get();
+			genericRecord = reader.read(null, decoder);
 		}
 		catch (IOException e) {
 			throw new CommandException("Could not serialize Avro: " + e.getMessage(), e);
 		}
-		catch (InterruptedException | ExecutionException ex) {
-			throw new CommandException("Failed sending record: " + ex.getMessage(), ex);
+
+		if (sendAsync) {
+			producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), genericRecord, headers), (metadata, exception) -> {
+				if (exception != null) {
+					lastError = new CommandException("Failed sending record: " + exception.getMessage(), exception);
+					return;
+				}
+				numAcked++;
+			});
+		}
+		else {
+			try {
+				producer.send(new ProducerRecord<>(topic, null, getKey(message, pa), genericRecord, headers)).get();
+				numAcked++;
+			}
+			catch (InterruptedException | ExecutionException ex) {
+				throw new CommandException("Failed sending record: " + ex.getMessage(), ex);
+			}
 		}
 	}
 
@@ -131,7 +226,7 @@ public class KafkaPutCommand extends AbstractPutCommand {
 	private Headers mapHeader(Message message) {
 		Headers headers = new RecordHeaders();
 		if (message.getProperties() != null) {
-			for (Entry<String, Object> entry: message.getProperties().entrySet()) {
+			for (Entry<String, Object> entry : message.getProperties().entrySet()) {
 				headers.add(new RecordHeader(entry.getKey(), entry.getValue().toString().getBytes(UTF_8)));
 			}
 		}
@@ -150,6 +245,21 @@ public class KafkaPutCommand extends AbstractPutCommand {
 
 	@Override
 	protected void close() {
+		// wait for all acks
+		synchronized (this) {
+			while(numAcked < numSend) {
+				try {
+					wait(100);
+				}
+				catch (InterruptedException e) {
+					Output.error("Unexpected interruption: " + e.getMessage());
+				}
+			}
+		}
+
+		if (transactional && !closed) {
+			producer.commitTransaction();
+		}
 		if (producer != null) {
 			producer.close();
 		}

--- a/plunger/pom.xml
+++ b/plunger/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.fusesource.jansi</groupId>
 			<artifactId>jansi</artifactId>
-			<version>1.18</version>
+			<version>2.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/plunger/src/main/java/de/galan/plunger/command/Command.java
+++ b/plunger/src/main/java/de/galan/plunger/command/Command.java
@@ -12,4 +12,5 @@ public interface Command {
 
 	public void execute(PlungerArguments pa) throws CommandException;
 
+	default void onError(CommandException exception) {}
 }

--- a/plunger/src/main/java/de/galan/plunger/command/Command.java
+++ b/plunger/src/main/java/de/galan/plunger/command/Command.java
@@ -5,12 +5,14 @@ import de.galan.plunger.domain.PlungerArguments;
 
 /**
  * A command plunger could execute
- * 
- * @author daniel
  */
 public interface Command {
 
 	public void execute(PlungerArguments pa) throws CommandException;
 
-	default void onError(CommandException exception) {}
+
+	default void onError(CommandException exception) {
+		// To be implemented by commands that need an error-handling after a CommandException is thrown
+	}
+
 }


### PR DESCRIPTION
This change provides two new kafka parameters:

- `async=bool`: Send all messages async without blocking after each produced record. This feature should used with transactions to guarantee the send and order.
- `tx=bool`: Use kafka transactions to rollback all messages in case of error. This will also make the producer idempotent. The transaction timeout (`txTimeout`) can be specified (default is 300,000ms or 5m). See also https://www.cloudkarafka.com/blog/apache-kafka-idempotent-producer-avoiding-message-duplication.html
