### PR TITLE
Buffered output

### DIFF
--- a/plunger/src/main/java/de/galan/plunger/application/Plunger.java
+++ b/plunger/src/main/java/de/galan/plunger/application/Plunger.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -12,6 +13,8 @@ import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 import org.fusesource.jansi.AnsiConsole;
+
+import com.google.common.base.Stopwatch;
 
 import de.galan.plunger.command.CommandName;
 import de.galan.plunger.config.Config;
@@ -36,6 +39,7 @@ public class Plunger {
 	public static void main(String[] args) {
 		AnsiConsole.systemInstall();
 		new Plunger().start(args);
+		Output.flush();
 	}
 
 
@@ -126,7 +130,7 @@ public class Plunger {
 			}
 		}
 		Output.println("\nPlunger homepage: " + DOCUMENTATION_URL);
-
+		Output.flush();
 		System.exit(status);
 	}
 

--- a/plunger/src/main/java/de/galan/plunger/command/generic/AbstractCatCommand.java
+++ b/plunger/src/main/java/de/galan/plunger/command/generic/AbstractCatCommand.java
@@ -33,7 +33,7 @@ public abstract class AbstractCatCommand extends AbstractCommand {
 
 	@Override
 	public void process(PlungerArguments pa) throws CommandException {
-		Message message = null;
+		Message message;
 		boolean firstMessage = true;
 		MutableLong counter = new MutableLong();
 		Long limit = pa.getCommandArgumentLong("n");
@@ -70,6 +70,7 @@ public abstract class AbstractCatCommand extends AbstractCommand {
 		if (!firstMessage) {
 			if (!pa.containsCommandArgument("e") && !pa.containsCommandArgument("d")) {
 				Output.println(StringUtils.repeat("-", 64));
+				Output.flush();
 			}
 		}
 		return false;
@@ -108,6 +109,7 @@ public abstract class AbstractCatCommand extends AbstractCommand {
 				Output.println(Color.YELLOW, message.getBody());
 			}
 		}
+		Output.flush();
 	}
 
 

--- a/plunger/src/main/java/de/galan/plunger/command/generic/AbstractCountCommand.java
+++ b/plunger/src/main/java/de/galan/plunger/command/generic/AbstractCountCommand.java
@@ -24,6 +24,7 @@ public abstract class AbstractCountCommand extends AbstractCommand {
 	@Override
 	protected void process(PlungerArguments pa) throws CommandException {
 		Output.println("" + getCount(pa));
+		Output.flush();
 	}
 
 

--- a/plunger/src/main/java/de/galan/plunger/command/generic/AbstractLsCommand.java
+++ b/plunger/src/main/java/de/galan/plunger/command/generic/AbstractLsCommand.java
@@ -38,6 +38,7 @@ public abstract class AbstractLsCommand extends AbstractCommand {
 			}
 			Output.println("");
 		}
+		Output.flush();
 	}
 
 

--- a/plunger/src/main/java/de/galan/plunger/command/generic/AbstractPutCommand.java
+++ b/plunger/src/main/java/de/galan/plunger/command/generic/AbstractPutCommand.java
@@ -35,11 +35,11 @@ public abstract class AbstractPutCommand extends AbstractCommand {
 		long lineCount = 0;
 
 		MessageMarshaller mm = pa.containsCommandArgument("d") ? new DirectMessageMarshaller() : new CompleteMessageMarshaller();
-		String line = null;
+		String line;
 		while((line = reader.read()) != null) {
 			lineCount++;
 			try {
-				Message msg = null;
+				Message msg;
 				try {
 					msg = mm.unmarshal(line);
 				}
@@ -80,6 +80,7 @@ public abstract class AbstractPutCommand extends AbstractCommand {
 			Output.print(Color.GREEN, marshalled[0]);
 			Output.print(marshalled[1]);
 			Output.println(Color.YELLOW, marshalled[2]);
+			Output.flush();
 		}
 	}
 

--- a/plunger/src/main/java/de/galan/plunger/util/Output.java
+++ b/plunger/src/main/java/de/galan/plunger/util/Output.java
@@ -2,6 +2,12 @@ package de.galan.plunger.util;
 
 import static org.fusesource.jansi.Ansi.*;
 
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
 import org.fusesource.jansi.Ansi.Color;
 
 
@@ -13,6 +19,8 @@ import org.fusesource.jansi.Ansi.Color;
 public class Output {
 
 	private static boolean colors = true;
+	private static final PrintWriter BUFFERED_STDOUT = new PrintWriter(new BufferedWriter(new OutputStreamWriter(new FileOutputStream(java.io.FileDescriptor.out),
+		StandardCharsets.UTF_8), 4096));
 
 
 	public static void setColor(boolean colors) {
@@ -21,22 +29,22 @@ public class Output {
 
 
 	public static void print(Color color, String text) {
-		System./**/out.print(colors ? ansi().fg(color).a(text).reset() : text);
+		BUFFERED_STDOUT.print(colors ? ansi().fg(color).a(text).reset() : text);
 	}
 
 
 	public static void println(Color color, String text) {
-		System./**/out.println(colors ? ansi().fg(color).a(text).reset() : text);
+		BUFFERED_STDOUT.println(colors ? ansi().fg(color).a(text).reset() : text);
 	}
 
 
 	public static void print(String line) {
-		System/**/.out.print(line);
+		BUFFERED_STDOUT.print(line);
 	}
 
 
 	public static void println(String line) {
-		System/**/.out.println(line);
+		BUFFERED_STDOUT.println(line);
 	}
 
 
@@ -44,4 +52,8 @@ public class Output {
 		System./**/err.println(colors ? ansi().fg(Color.RED).a(text).reset() : text);
 	}
 
+
+	public static void flush() {
+		BUFFERED_STDOUT.flush();
+	}
 }

--- a/plunger/src/main/java/de/galan/plunger/util/VersionUtil.java
+++ b/plunger/src/main/java/de/galan/plunger/util/VersionUtil.java
@@ -18,6 +18,7 @@ public class VersionUtil {
 		try {
 			pp.load(is);
 			Output.println(pp.getProperty("artifactId") + " version \"" + pp.getProperty("version") + "\"");
+			Output.flush();
 		}
 		catch (IOException ex) {
 			Output.error("Could not read version information from jar");

--- a/plunger/src/test/java/de/galan/plunger/command/CompleteMessageMarshallerTest.java
+++ b/plunger/src/test/java/de/galan/plunger/command/CompleteMessageMarshallerTest.java
@@ -64,6 +64,7 @@ public class CompleteMessageMarshallerTest {
 		// marshall
 		String marshal = mm.marshal(m);
 		Output.print(marshal);
+		Output.flush();
 		assertThat(marshal).contains("\"a\":\"a\"");
 		assertThat(marshal).contains("\"b\":123");
 		assertThat(marshal).contains("\"c\":true");


### PR DESCRIPTION
This increases the pcat performance dramatically by replacing the blocking writes to stdout by a buffer.